### PR TITLE
mousepad: version bumped to 0.3.0.

### DIFF
--- a/mousepad/DEPENDS
+++ b/mousepad/DEPENDS
@@ -1,1 +1,3 @@
-depends libxfcegui4
+depends desktop-file-utils
+depends dbus-glib
+depends gtksourceview

--- a/mousepad/DETAILS
+++ b/mousepad/DETAILS
@@ -1,12 +1,11 @@
           MODULE=mousepad
-           MAJOR=0.2
-         VERSION=$MAJOR.16
+         VERSION=0.3.0
           SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/$MAJOR
-      SOURCE_VFY=sha1:4e63033e0a71578f3ec9a0d2e6a505efd0424ef9
+      SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION::3}
+      SOURCE_VFY=sha1:2389d46a4df1683f17f1a9162173f62b3ca08fc2
         WEB_SITE=http://erikharrison.net
          ENTERED=20050218
-         UPDATED=20090227
+         UPDATED=20121231
            SHORT="Lighweight xfce text editor"
 
 cat << EOF


### PR DESCRIPTION
It does not depend on libxfcegui4. In fact it's independent of xfce.
