### PR TITLE
xfce4: changed optional_depends on Terminal to xfce4-terminal

### DIFF
--- a/xfce4/DEPENDS
+++ b/xfce4/DEPENDS
@@ -7,4 +7,4 @@ depends xfce4-session
 depends xfce4-icon-theme
 
 optional_depends Thunar     "" "" "For the new xfce4 filemanager"
-optional_depends Terminal   "" "" "For the new xfce4 xterm"
+optional_depends xfce4-terminal   "" "" "For the new xfce4 xterm"

--- a/xfce4/DETAILS
+++ b/xfce4/DETAILS
@@ -4,7 +4,7 @@ SOURCE_DIRECTORY=${BUILD_DIRECTORY}/${MODULE}
         WEB_SITE=http://www.xfce.org
       MAINTAINER=jasper@lunar-linux.org
          ENTERED=20030715
-         UPDATED=20120429
+         UPDATED=20140727
            SHORT="A lightweight desktop environment based on GTK2"
          PROFILE=yes
 


### PR DESCRIPTION
assuming that xfce4-terminal is the new name of replacement for Terminal
