### PR TITLE
Version bump to Xfce 4.13.x series and extras

### DIFF
--- a/Thunar/BUILD
+++ b/Thunar/BUILD
@@ -1,0 +1,3 @@
+OPTS+=" --disable-static --disable-debug --enable-gio-unix" &&
+
+default_build

--- a/Thunar/DEPENDS
+++ b/Thunar/DEPENDS
@@ -8,6 +8,12 @@ optional_depends libgudev \
                  "--disable-gudev" \
                  "enable gudev support (required by thunar-volman)"
 
-optional_depends gvfs    "" "" "enable trash support and mounting remote filesystems" 
+optional_depends gobject-introspection \
+                 "--enable-introspection" \
+                 "--disable-introspection" \
+                 "enable gobject introspection support"
+
+optional_depends gvfs    "" "" "enable trash support and mounting remote filesystems"
 optional_depends libexif "" "" "enable Exif support"
 optional_depends xfconf  "" "" "enable Xfconf support"
+optional_depends tumbler "" "" "enable thumbnail previews"

--- a/Thunar/DEPENDS
+++ b/Thunar/DEPENDS
@@ -3,17 +3,19 @@ depends libpng
 depends shared-mime-info
 depends desktop-file-utils
 
-optional_depends libgudev \
-                 "--enable-gudev" \
-                 "--disable-gudev" \
-                 "enable gudev support (required by thunar-volman)"
-
 optional_depends gobject-introspection \
                  "--enable-introspection" \
                  "--disable-introspection" \
-                 "enable gobject introspection support"
+                 "Enable GObject Introspection support"
 
-optional_depends gvfs    "" "" "enable trash support and mounting remote filesystems"
-optional_depends libexif "" "" "enable Exif support"
-optional_depends xfconf  "" "" "enable Xfconf support"
-optional_depends tumbler "" "" "enable thumbnail previews"
+optional_depends libgudev \
+                 "--enable-gudev" \
+                 "--disable-gudev" \
+                 "Enable gudev support (required by thunar-volman)"
+
+optional_depends libexif \
+                 "--enable-exif" \
+		 "--disable-exif" \
+		 "Enable Exif support"
+
+optional_depends tumbler "" "" "Enable thumbnail previews"

--- a/Thunar/DETAILS
+++ b/Thunar/DETAILS
@@ -1,11 +1,11 @@
           MODULE=Thunar
-         VERSION=1.8.1
+         VERSION=1.8.2
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/thunar/${VERSION%.*}
-      SOURCE_VFY=sha256:96fabaa68db32f513e9bcb34fa2a26c1462127727fad0bc25a8a5ba9aab4c12c
+      SOURCE_VFY=sha256:75f91045541eb5983e772a564d97f23e5995256bfb9863e0f4a015393421d428
         WEB_SITE=http://thunar.xfce.org
          ENTERED=20060407
-         UPDATED=20180816
+         UPDATED=20180927
            SHORT="File manager for xfce"
 
 cat << EOF

--- a/exo/DEPENDS
+++ b/exo/DEPENDS
@@ -1,6 +1,8 @@
 depends URI
 depends libxfce4ui
+depends gtk+-2
 depends intltool
+depends hicolor-icon-theme
 
 optional_depends pygtk \
                  "--enable-python"  \

--- a/exo/DETAILS
+++ b/exo/DETAILS
@@ -1,11 +1,11 @@
           MODULE=exo
-         VERSION=0.12.2
+         VERSION=0.12.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:6d4b0a88c1e1d3d5ed612cbf012c7511ef67b1636f4f85caa9dc68649b7e6350
+      SOURCE_VFY=sha256:b96fe86bb504aa9b3332b96105d755f5d9052c903fd6574b512a5ef76c0ad439
         WEB_SITE=http://www.os-cillation.de/en/open-source-projekte/libexo
          ENTERED=20040930
-         UPDATED=20180816
+         UPDATED=20181016
            SHORT="The Xfce extension library"
 
 cat << EOF

--- a/libxfce4ui/DEPENDS
+++ b/libxfce4ui/DEPENDS
@@ -1,17 +1,34 @@
-depends  gtk+-2
-
-# libxfce4ui-2 requires GTK3
 depends  gtk+-3
 
 depends  libxml2
 depends  libxfce4util
 depends  xfconf
 
-optional_depends  gobject-introspection "--enable-introspection" "--disable-introspection" "For GObjection Introspection support"
-optional_depends  vala "--enable-vala" "--disable-vala" "For Vala support"
-optional_depends  libglade             "" "" "Glade Interface Designer"
-optional_depends  startup-notification "" "" "Startup notification"
+optional_depends gtk+-2 \
+                 "--enable-gtk2" \
+		 "--disable-gtk2" \
+		 "For GTK+ 2 support"
+
+optional_depends gobject-introspection \
+                 "--enable-introspection" \
+		 "--disable-introspection" \
+		 "For GObject Introspection support"
+
+optional_depends vala \
+                 "--enable-vala" \
+		 "--disable-vala" \
+		 "For Vala support"
+
+optional_depends libglade \
+                 "--enable-gladeui --enable-gladeui2" \
+		 "--disable-gladeui --disable-gladeui2" \
+		 "For Glade Interface Designer"
+
+optional_depends startup-notification \
+                 "--enable-startup-notification" \
+		 "--disable-startup-notification" \
+		 "Startup notification"
 
 # not real depends, but we really want them
-depends  gtk-xfce-engine
-depends  xfce4-icon-theme
+#depends  gtk-xfce-engine
+#depends  xfce4-icon-theme

--- a/libxfce4ui/DEPENDS
+++ b/libxfce4ui/DEPENDS
@@ -7,6 +7,8 @@ depends  libxml2
 depends  libxfce4util
 depends  xfconf
 
+optional_depends  gobject-introspection "--enable-introspection" "--disable-introspection" "For GObjection Introspection support"
+optional_depends  vala "--enable-vala" "--disable-vala" "For Vala support"
 optional_depends  libglade             "" "" "Glade Interface Designer"
 optional_depends  startup-notification "" "" "Startup notification"
 

--- a/libxfce4ui/DETAILS
+++ b/libxfce4ui/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libxfce4ui
-         VERSION=4.12.1
+         VERSION=4.13.4
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha1:ef687867bd087b5fc2befee0e8ca1a281f6bf165
+      SOURCE_VFY=sha256:d63fcdb8e5acb6f0d26075ea17d320dbfbec2058567cd67cb99824c7402a1f79
         WEB_SITE=http://www.xfce.org
          ENTERED=20030715
-         UPDATED=20150417
+         UPDATED=20181207
            SHORT="Widget library for Xfce4"
 
 cat << EOF

--- a/libxfce4util/DEPENDS
+++ b/libxfce4util/DEPENDS
@@ -1,1 +1,11 @@
 depends  glib-2
+
+optional_depends vala \
+                 "--enable-vala" \
+		 "--disable-vala" \
+		 "For Vala support"
+
+optional_depends gobject-introspection \
+                 "--enable-introspection" \
+		 "--disable-introspection" \
+		 "For GObject instrospection support"

--- a/libxfce4util/DETAILS
+++ b/libxfce4util/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libxfce4util
-         VERSION=4.12.1
+         VERSION=4.13.2
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha1:fbea10b13db55c1f7756ec36ea7c8e84ca781492
+      SOURCE_VFY=sha256:c58275ff650080369e742695862c811cb78402c85f243ea0b5aec186027be361
         WEB_SITE=http://www.xfce.org
          ENTERED=20030715
-         UPDATED=20150228
+         UPDATED=20181207
            SHORT="A utility library for Xfce4"
 
 cat << EOF

--- a/parole/DEPENDS
+++ b/parole/DEPENDS
@@ -1,11 +1,24 @@
-depends gstreamer-10
 depends libxfce4ui
 depends libxfce4util
-depends libxfcegui4
 depends dbus-glib
-depends glib-2
-depends gtk+-2
-depends gst-plugins-base
+depends gst-plugins-base-1.0
+depends gst-plugins-good-1.0
 
-optional_depends libnotify "--enable-notify-plugin" "--disable-notify-plugin" "for the notification plugin"
-optional_depends taglib    "--enable-taglib" "--disable-taglib" "for taglib support"
+optional_depends gst-libav "" "" "extra media codecs"
+optional_depends gst-plugins-bad-1.0 "" "" "extra media codecs"
+optional_depends gst-plugins-ugly-1.0 "" "" "extra media codecs"
+
+optional_depends libnotify \
+                 "--enable-notify-plugin" \
+                 "--disable-notify-plugin" \
+                 "for the notification plugin"
+
+optional_depends taglib \
+                 "--enable-taglib" \
+                 "--disable-taglib" \
+                 "for taglib support"
+
+optional_depends gtk-doc \
+                 "--enable-gtk-doc"  \
+                 "--disable-gtk-doc" \
+                 "for building documentation"

--- a/parole/DETAILS
+++ b/parole/DETAILS
@@ -1,15 +1,15 @@
           MODULE=parole
-         VERSION=0.8.1
+         VERSION=1.0.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:4b216f5200490f8d2a9bf1b3fcd9a8b20834c95249bf13b9170c82e1fcbd80f4
+      SOURCE_VFY=sha256:8ad2931fdb35415cc3d7551b5f2207bfaa1aba15545accbacbb4984cdabd7099
         WEB_SITE=http://goodies.xfce.org/projects/applications/$MODULE
          ENTERED=20110329
-         UPDATED=20151018
+         UPDATED=20180816
            SHORT="media player for the Xfce desktop"
 
 cat << EOF
-Parole is a modern simple media player based on the GStreamer framework
-and written to fit well in the Xfce desktop. Parole is designed with
-simplicity, speed and resource usage in mind.
+Parole is a modern simple media player based on the GStreamer framework and
+written to fit well in the Xfce desktop. Parole is designed with simplicity,
+speed and resource usage in mind.
 EOF

--- a/ristretto/DEPENDS
+++ b/ristretto/DEPENDS
@@ -3,3 +3,4 @@ depends libxfce4ui
 depends libexif
 depends dbus-glib
 
+optional_depends tumbler "" "" "for thumbnailing support"

--- a/ristretto/DETAILS
+++ b/ristretto/DETAILS
@@ -1,11 +1,11 @@
           MODULE=ristretto
-         VERSION=0.8.2
+         VERSION=0.8.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION%.*}/
-      SOURCE_VFY=sha256:f8f3b77ca6fc77ddf8cff1bb52e5c5802c462663f72f324393b3a0360f6901b8
+      SOURCE_VFY=sha256:8c9c11760816dfd9ed57fb8b9df86c6a98a2604ab551be3133996a1c32ca2665
         WEB_SITE=http://goodies.xfce.org/projects/applications/ristretto
          ENTERED=20070826
-         UPDATED=20170203
+         UPDATED=20180819
            SHORT="Fast and lightweight picture-viewer"
 
 cat << EOF

--- a/thunar-volman/DETAILS
+++ b/thunar-volman/DETAILS
@@ -1,11 +1,11 @@
           MODULE=thunar-volman
-         VERSION=0.8.1
+         VERSION=0.9.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha1:fa76fa0089f85f23b1efbdfb76a70039de7f7e8b
+      SOURCE_VFY=sha256:
         WEB_SITE=http://goodies.xfce.org/projects/thunar-plugins/thunar-volman
          ENTERED=20070123
-         UPDATED=20150228
+         UPDATED=20181129
            SHORT="Automatic management of removable drives and media"
 
 cat << EOF

--- a/tumbler/BUILD
+++ b/tumbler/BUILD
@@ -1,0 +1,5 @@
+OPTS+=" --disable-debug \
+        --disable-static \
+        --disable-gstreamer-thumbnailer"
+
+default_build

--- a/tumbler/DETAILS
+++ b/tumbler/DETAILS
@@ -1,12 +1,12 @@
           MODULE=tumbler
-         VERSION=0.2.0
+         VERSION=0.2.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/tumbler/${VERSION%.*}
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha256:4e27a59694b0a5cc69ebccbdb00c724e670b5b7c30bc4dc0b461aac93f234fac
+      SOURCE_VFY=sha256:d022e1bd1559fba33e4bf20fb053b219eca17676ebffb1ceb214fcd58a187d40
         WEB_SITE=http://xfce.org
          ENTERED=20110418
-         UPDATED=20180816
+         UPDATED=20180914
            SHORT="XFCE thumbnailer"
 
 cat <<EOF

--- a/tumbler/patch.d/move-sparse-file-check-to-plugins.patch
+++ b/tumbler/patch.d/move-sparse-file-check-to-plugins.patch
@@ -1,0 +1,411 @@
+From da29dad8676b38b3e29396db1442d0ede6f6385d Mon Sep 17 00:00:00 2001
+From: Ali Abdallah <ali@xfce.org>
+Date: Sun, 21 Oct 2018 11:14:16 +0200
+Subject: Check for sparse video files only on plugin side.
+
+Move the sparse video files check to ffmpeg and gstreamer plugins.
+---
+ plugins/ffmpeg-thumbnailer/ffmpeg-thumbnailer.c | 18 ++++--
+ plugins/gst-thumbnailer/gst-thumbnailer.c       |  8 +++
+ tumbler/tumbler-util.c                          | 41 ++++++++++++-
+ tumbler/tumbler-util.h                          | 10 ++-
+ tumblerd/tumbler-registry.c                     | 82 ++++++++-----------------
+ 5 files changed, 92 insertions(+), 67 deletions(-)
+
+diff --git a/plugins/ffmpeg-thumbnailer/ffmpeg-thumbnailer.c b/plugins/ffmpeg-thumbnailer/ffmpeg-thumbnailer.c
+index 81f2922..6bc9de3 100644
+--- a/plugins/ffmpeg-thumbnailer/ffmpeg-thumbnailer.c
++++ b/plugins/ffmpeg-thumbnailer/ffmpeg-thumbnailer.c
+@@ -10,11 +10,11 @@
+  *
+  * This library is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Library General Public License for more details.
+  *
+- * You should have received a copy of the GNU Library General 
+- * Public License along with this library; if not, write to the 
++ * You should have received a copy of the GNU Library General
++ * Public License along with this library; if not, write to the
+  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  * Boston, MA 02110-1301, USA.
+  */
+@@ -149,7 +149,7 @@ generate_pixbuf (GdkPixbuf *source,
+     dest_height = rint (source_height / wratio);
+ 
+   /* scale the pixbuf down to the desired size */
+-  return gdk_pixbuf_scale_simple (source, MAX (dest_width, 1), MAX (dest_height, 1), 
++  return gdk_pixbuf_scale_simple (source, MAX (dest_width, 1), MAX (dest_height, 1),
+                                   GDK_INTERP_BILINEAR);
+ }
+ 
+@@ -180,9 +180,17 @@ ffmpeg_thumbnailer_create (TumblerAbstractThumbnailer *thumbnailer,
+   g_return_if_fail (TUMBLER_IS_FILE_INFO (info));
+ 
+   /* do nothing if cancelled */
+-  if (g_cancellable_is_cancelled (cancellable)) 
++  if (g_cancellable_is_cancelled (cancellable))
+     return;
+ 
++  /* Check if is a sparse video file */
++  if (tumbler_util_guess_is_sparse (info))
++  {
++    g_debug ("Video file '%s' is probably sparse, skipping\n",
++             tumbler_file_info_get_uri (info));
++    return;
++  }
++
+   /* fetch required info */
+   thumbnail = tumbler_file_info_get_thumbnail (info);
+   g_assert (thumbnail != NULL);
+diff --git a/plugins/gst-thumbnailer/gst-thumbnailer.c b/plugins/gst-thumbnailer/gst-thumbnailer.c
+index 284a0b9..73f884b 100644
+--- a/plugins/gst-thumbnailer/gst-thumbnailer.c
++++ b/plugins/gst-thumbnailer/gst-thumbnailer.c
+@@ -570,6 +570,14 @@ gst_thumbnailer_create (TumblerAbstractThumbnailer *thumbnailer,
+   if (g_cancellable_is_cancelled (cancellable))
+     return;
+ 
++  /* Check if is a sparse video file */
++  if (tumbler_util_guess_is_sparse (info))
++  {
++    g_debug ("Video file '%s' is probably sparse, skipping\n",
++             tumbler_file_info_get_uri (info));
++    return;
++  }
++
+   /* get size of dest thumb */
+   thumbnail = tumbler_file_info_get_thumbnail (info);
+   flavor = tumbler_thumbnail_get_flavor (thumbnail);
+diff --git a/tumbler/tumbler-util.c b/tumbler/tumbler-util.c
+index 9d656d5..a414e26 100644
+--- a/tumbler/tumbler-util.c
++++ b/tumbler/tumbler-util.c
+@@ -9,11 +9,11 @@
+  *
+  * This library is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Library General Public License for more details.
+  *
+- * You should have received a copy of the GNU Library General 
+- * Public License along with this library; if not, write to the 
++ * You should have received a copy of the GNU Library General
++ * Public License along with this library; if not, write to the
+  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  * Boston, MA 02110-1301, USA.
+  */
+@@ -29,8 +29,12 @@
+ #include <glib.h>
+ #include <gio/gio.h>
+ 
++#include <sys/stat.h>
++
+ #include <tumbler/tumbler-util.h>
+ 
++/* Float block size used in the stat struct */
++#define TUMBLER_STAT_BLKSIZE 512.
+ 
+ 
+ gchar **
+@@ -130,3 +134,34 @@ tumbler_util_get_settings (void)
+ 
+   return settings;
+ }
++
++
++gboolean  tumbler_util_guess_is_sparse (TumblerFileInfo *info)
++{
++  gchar *filename;
++  struct stat sb;
++  gboolean ret_val = FALSE;
++
++  g_return_val_if_fail (TUMBLER_IS_FILE_INFO (info), FALSE);
++
++  filename = g_filename_from_uri (tumbler_file_info_get_uri (info), NULL, NULL);
++
++  if (G_LIKELY(filename))
++  {
++    stat (filename, &sb);
++
++    g_free (filename);
++
++    /* Test sparse files on regular ones */
++    if (S_ISREG (sb.st_mode))
++    {
++      if (((TUMBLER_STAT_BLKSIZE * sb.st_blocks) / sb.st_size) < 0.8)
++      {
++        ret_val = TRUE;
++      }
++    }
++  }
++
++  return ret_val;
++}
++
+diff --git a/tumbler/tumbler-util.h b/tumbler/tumbler-util.h
+index b68db0a..809332e 100644
+--- a/tumbler/tumbler-util.h
++++ b/tumbler/tumbler-util.h
+@@ -9,11 +9,11 @@
+  *
+  * This library is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Library General Public License for more details.
+  *
+- * You should have received a copy of the GNU Library General 
+- * Public License along with this library; if not, write to the 
++ * You should have received a copy of the GNU Library General
++ * Public License along with this library; if not, write to the
+  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  * Boston, MA 02110-1301, USA.
+  */
+@@ -23,12 +23,16 @@
+ 
+ #include <glib.h>
+ 
++#include <tumbler/tumbler-file-info.h>
++
+ G_BEGIN_DECLS
+ 
+ gchar **tumbler_util_get_supported_uri_schemes (void) G_GNUC_MALLOC;
+ 
+ GKeyFile *tumbler_util_get_settings (void) G_GNUC_MALLOC;
+ 
++gboolean  tumbler_util_guess_is_sparse (TumblerFileInfo *info);
++
+ G_END_DECLS
+ 
+ #endif /* !__TUMBLER_UTIL_H__ */
+diff --git a/tumblerd/tumbler-registry.c b/tumblerd/tumbler-registry.c
+index b87e2c1..317c853 100644
+--- a/tumblerd/tumbler-registry.c
++++ b/tumblerd/tumbler-registry.c
+@@ -3,18 +3,18 @@
+  * Copyright (c) 2009-2011 Jannis Pohlmann <jannis@xfce.org>
+  * Copyright (c) 2018      Ali Abdallah    <ali@xfce.org>
+  *
+- * This program is free software; you can redistribute it and/or 
++ * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU General Public License as
+- * published by the Free Software Foundation; either version 2 of 
++ * published by the Free Software Foundation; either version 2 of
+  * the License, or (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+- * You should have received a copy of the GNU General Public 
+- * License along with this program; if not, write to the Free 
++ * You should have received a copy of the GNU General Public
++ * License along with this program; if not, write to the Free
+  * Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  * Boston, MA 02110-1301, USA.
+  */
+@@ -26,7 +26,6 @@
+ #include <glib.h>
+ #include <glib-object.h>
+ 
+-#include <sys/stat.h>
+ 
+ #include <tumbler/tumbler.h>
+ 
+@@ -34,8 +33,6 @@
+ #include <tumblerd/tumbler-specialized-thumbnailer.h>
+ #include <tumblerd/tumbler-utils.h>
+ 
+-/* Float block size used in the stat struct */
+-#define TUMBLER_STAT_BLKSIZE 512.
+ 
+ static void                tumbler_registry_finalize                  (GObject            *object);
+ static void                tumbler_registry_remove_thumbnailer        (const gchar        *key,
+@@ -83,11 +80,11 @@ tumbler_registry_class_init (TumblerRegistryClass *klass)
+   GObjectClass *gobject_class;
+ 
+   /* pre-allocate the required quarks */
+-  tumbler_registry_visited_quark = 
++  tumbler_registry_visited_quark =
+     g_quark_from_static_string ("tumbler-registry-visited-quark");
+ 
+   gobject_class = G_OBJECT_CLASS (klass);
+-  gobject_class->finalize = tumbler_registry_finalize; 
++  gobject_class->finalize = tumbler_registry_finalize;
+ }
+ 
+ 
+@@ -174,7 +171,7 @@ tumbler_registry_compare (TumblerThumbnailer *a,
+   g_return_val_if_fail (TUMBLER_IS_THUMBNAILER (a), 0);
+   g_return_val_if_fail (TUMBLER_IS_THUMBNAILER (b), 0);
+ 
+-  /* TODO Rewrite this based on a single get_registered() time function 
++  /* TODO Rewrite this based on a single get_registered() time function
+    * for all thumbnailer types */
+ 
+   if (!TUMBLER_IS_SPECIALIZED_THUMBNAILER (a) || !TUMBLER_IS_SPECIALIZED_THUMBNAILER (b))
+@@ -367,7 +364,7 @@ tumbler_registry_add (TumblerRegistry    *registry,
+ 
+       if (list != NULL)
+         {
+-          /* we already have thumbnailers for this combination. insert the new 
++          /* we already have thumbnailers for this combination. insert the new
+            * one at the right position in the list */
+           *list = g_list_insert_sorted (*list, g_object_ref (thumbnailer),
+                                         (GCompareFunc) tumbler_registry_compare);
+@@ -386,7 +383,7 @@ tumbler_registry_add (TumblerRegistry    *registry,
+     }
+ 
+   /* connect to the unregister signal of the thumbnailer */
+-  g_signal_connect_swapped (thumbnailer, "unregister", 
++  g_signal_connect_swapped (thumbnailer, "unregister",
+                             G_CALLBACK (tumbler_registry_remove), registry);
+ 
+   g_strfreev (hash_keys);
+@@ -409,11 +406,11 @@ tumbler_registry_remove (TumblerRegistry    *registry,
+ 
+   tumbler_mutex_lock (registry->mutex);
+ 
+-  g_signal_handlers_disconnect_matched (thumbnailer, G_SIGNAL_MATCH_DATA, 
++  g_signal_handlers_disconnect_matched (thumbnailer, G_SIGNAL_MATCH_DATA,
+                                         0, 0, NULL, NULL, registry);
+-                                        
++
+   /* remove the thumbnailer from all hash key lists */
+-  g_hash_table_foreach (registry->thumbnailers, 
++  g_hash_table_foreach (registry->thumbnailers,
+                         (GHFunc) tumbler_registry_remove_thumbnailer, thumbnailer);
+ 
+   tumbler_mutex_unlock (registry->mutex);
+@@ -465,42 +462,15 @@ tumbler_registry_get_thumbnailer_array (TumblerRegistry    *registry,
+   /* iterate over all URIs */
+   for (n = 0; n < length; ++n)
+     {
+-      gchar *filename;
+-      struct stat sb;
+-
+       g_assert (TUMBLER_IS_FILE_INFO (infos[n]));
+ 
+       /* reset */
+       file_size = 0;
+ 
+-      filename = g_filename_from_uri (tumbler_file_info_get_uri (infos[n]), NULL, NULL);
+-
+-      if (G_LIKELY(filename))
+-      {
+-        stat (filename, &sb);
+-
+-        g_free (filename);
+-
+-        /* Test sparse files on regular ones */
+-        if (S_ISREG (sb.st_mode))
+-        {
+-          if (((TUMBLER_STAT_BLKSIZE * sb.st_blocks) / sb.st_size) < 0.8)
+-          {
+-            g_debug ("'%s' is probably a sparse file, skipping\n", tumbler_file_info_get_uri (infos[n]));
+-            continue;
+-          }
+-        }
+-      }
+-      else
+-      {
+-        g_warning ("Failed to get filename from uri for '%s', skipping\n", tumbler_file_info_get_uri (infos[n]));
+-        continue;
+-      }
+-
+       /* determine the URI scheme and generate a hash key */
+       gfile = g_file_new_for_uri (tumbler_file_info_get_uri (infos[n]));
+       scheme = g_file_get_uri_scheme (gfile);
+-      hash_key = g_strdup_printf ("%s-%s", scheme, 
++      hash_key = g_strdup_printf ("%s-%s", scheme,
+                                   tumbler_file_info_get_mime_type (infos[n]));
+ 
+       /* get list of thumbnailer that can handle this URI/MIME type pair */
+@@ -593,8 +563,8 @@ tumbler_registry_update_supported (TumblerRegistry *registry)
+     g_object_set_qdata (lp->data, tumbler_registry_visited_quark, NULL);
+ 
+   /* create a hash table to collect unique URI scheme / MIME type pairs */
+-  unique_pairs = g_hash_table_new_full (g_str_hash, g_str_equal, 
+-                                        (GDestroyNotify) g_free, 
++  unique_pairs = g_hash_table_new_full (g_str_hash, g_str_equal,
++                                        (GDestroyNotify) g_free,
+                                         (GDestroyNotify) free_pair);
+ 
+   /* prepare array */
+@@ -611,8 +581,8 @@ tumbler_registry_update_supported (TumblerRegistry *registry)
+       uri_schemes = tumbler_thumbnailer_get_uri_schemes (lp->data);
+ 
+       /* insert all MIME types & URI schemes into the hash table */
+-      for (n = 0; 
+-           mime_types != NULL && uri_schemes != NULL && mime_types[n] != NULL; 
++      for (n = 0;
++           mime_types != NULL && uri_schemes != NULL && mime_types[n] != NULL;
+            ++n)
+         {
+           /* remember the MIME type so that we can later reuse it without copying */
+@@ -620,8 +590,8 @@ tumbler_registry_update_supported (TumblerRegistry *registry)
+ 
+           for (u = 0; uri_schemes[u] != NULL; ++u)
+             {
+-              /* remember the URI scheme for this pair so that we can later reuse it 
+-               * without copying. Only remember it once (n==0) to avoid segmentation 
++              /* remember the URI scheme for this pair so that we can later reuse it
++               * without copying. Only remember it once (n==0) to avoid segmentation
+                * faults when freeing the list */
+               if (n == 0)
+                 g_ptr_array_add (used_strings, uri_schemes[u]);
+@@ -646,9 +616,9 @@ tumbler_registry_update_supported (TumblerRegistry *registry)
+       g_free (mime_types);
+       g_free (uri_schemes);
+ 
+-      /* mark the thumbnailer as visited so we don't generate its 
++      /* mark the thumbnailer as visited so we don't generate its
+        * MIME type & URI scheme pairs multiple times */
+-      g_object_set_qdata (lp->data, tumbler_registry_visited_quark, 
++      g_object_set_qdata (lp->data, tumbler_registry_visited_quark,
+                           GUINT_TO_POINTER (1));
+     }
+ 
+@@ -667,7 +637,7 @@ tumbler_registry_update_supported (TumblerRegistry *registry)
+   /* insert all unique URI scheme / MIME type pairs into string arrays */
+   n = 0;
+   g_hash_table_iter_init (&iter, unique_pairs);
+-  while (g_hash_table_iter_next (&iter, NULL, (gpointer) &pair)) 
++  while (g_hash_table_iter_next (&iter, NULL, (gpointer) &pair))
+     {
+       /* fill the cache arrays with copied values */
+       registry->uri_schemes[n] = g_strdup (pair[0]);
+@@ -700,7 +670,7 @@ tumbler_registry_get_supported (TumblerRegistry     *registry,
+   g_return_if_fail (TUMBLER_IS_REGISTRY (registry));
+ 
+   tumbler_mutex_lock (registry->mutex);
+-  
++
+   if (uri_schemes != NULL)
+     *uri_schemes = (const gchar *const *)registry->uri_schemes;
+ 
+@@ -740,14 +710,14 @@ tumbler_registry_set_preferred (TumblerRegistry    *registry,
+   g_return_if_fail (thumbnailer == NULL || TUMBLER_IS_THUMBNAILER (thumbnailer));
+ 
+   tumbler_mutex_lock (registry->mutex);
+-  
++
+   if (thumbnailer == NULL)
+     {
+       g_hash_table_remove (registry->preferred_thumbnailers, hash_key);
+     }
+   else
+     {
+-      g_hash_table_insert (registry->preferred_thumbnailers, 
++      g_hash_table_insert (registry->preferred_thumbnailers,
+                            g_strdup (hash_key), g_object_ref (thumbnailer));
+     }
+ 
+-- 
+cgit v1.2.1
+

--- a/xarchiver/DEPENDS
+++ b/xarchiver/DEPENDS
@@ -1,1 +1,3 @@
-depends  gtk+-2
+depends gtk+-3
+
+optional_depends gtk+-2 "--enable-gtk2" "--disable-gtk2" "for GTK+ 2.x support"

--- a/xarchiver/DETAILS
+++ b/xarchiver/DETAILS
@@ -1,16 +1,16 @@
           MODULE=xarchiver
-         VERSION=0.5.4.10
+         VERSION=0.5.4.13
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=http://github.com/ib/xarchiver/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:bb452d8ef4eabb52ab1313b3867156ea5030b75f9e59c59c7ef487c8db9dbea4
+      SOURCE_VFY=sha256:617154435731554b793ab00cc373d957c066dc29444c6189029299a89430776c
         WEB_SITE=http://xarchiver.sourceforge.net
          ENTERED=20060407
-         UPDATED=20170617
+         UPDATED=20180816
            SHORT="A simple archive manager"
 
 cat << EOF
-Xarchiver is a GTK+-2 frontend to 7z, zip, rar, tar, bzip2, gzip,
-arj, lha, rpm, and deb (open and extract only). Xarchiver allows
-you to create, add, extract, and delete files in the above formats.
-7z, zip, rar, arj password protected archives are supported too.
+Xarchiver is a GTK+-2 frontend to 7z, zip, rar, tar, bzip2, gzip, arj, lha,
+rpm, and deb (open and extract only). Xarchiver allows you to create, add,
+extract, and delete files in the above formats. 7z, zip, rar, arj password
+protected archives are supported too.
 EOF

--- a/xfce4-appfinder/DETAILS
+++ b/xfce4-appfinder/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-appfinder
-         VERSION=4.12.0
+         VERSION=4.13.2
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha1:c6fe75b140e6c864654e9485e30a4718cdfd7321
+      SOURCE_VFY=sha256:fd774acbcab08dbb88bcbf28eecf73ec9f55b13e1f2058021b63f703c4989d97
         WEB_SITE=http://www.xfce.org
          ENTERED=20041003
-         UPDATED=20150228
+         UPDATED=20181207
            SHORT="Easy search available applications"
 
 cat << EOF

--- a/xfce4-battery-plugin/DETAILS
+++ b/xfce4-battery-plugin/DETAILS
@@ -1,12 +1,11 @@
           MODULE=xfce4-battery-plugin
-           MAJOR=1.0
-         VERSION=$MAJOR.5
+         VERSION=1.1.1
           SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/$MAJOR
-      SOURCE_VFY=sha1:f1748044874909e434b0d325068289d948f999d7
+      SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}
+      SOURCE_VFY=sha256:1e94969b93e0c1d6da87364b64c0cdfb40bae5e4a055039be8b67b9e5b3dd44b
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-battery-plugin
          ENTERED=20061124
-         UPDATED=20120704
+         UPDATED=20180923
            SHORT="battery monitor panel plugin for Xfce4"
 
 cat << EOF

--- a/xfce4-clipman-plugin/BUILD
+++ b/xfce4-clipman-plugin/BUILD
@@ -1,10 +1,5 @@
-(
+OPTS+=" --disable-static --disable-debug"
 
-  OPTS+=" --disable-static" &&
+autoconf &&
 
-  sedit 's;exo-0.3;exo-1;' configure.ac &&
-  autoconf &&
-
-  default_build
-
-) > $C_FIFO 2>&1
+default_build

--- a/xfce4-clipman-plugin/DEPENDS
+++ b/xfce4-clipman-plugin/DEPENDS
@@ -1,3 +1,6 @@
 depends libunique
 depends xfce4-panel
 depends libXtst
+depends intltool
+
+optional_depends qrencode "" "" "for QR Code symbol support"

--- a/xfce4-clipman-plugin/DETAILS
+++ b/xfce4-clipman-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-clipman-plugin
-         VERSION=1.2.6
+         VERSION=1.4.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha1:71767fef0a8366bb9a6bd3edeacf4a8dabdcaa40
+      SOURCE_VFY=sha256i:29cdb85efb54bd5c9c04cc695b7c4914d6dff972b9fd969cbfb5504e9c632ad2
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-clipman-plugin
          ENTERED=20061124
-         UPDATED=20140801
+         UPDATED=20181030
            SHORT="clipboard plugin for the Xfce panel"
 
 cat << EOF

--- a/xfce4-clipman-plugin/PRE_BUILD
+++ b/xfce4-clipman-plugin/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build
+
+sedit 's;exo-0.3;exo-1;' configure.ac

--- a/xfce4-cpufreq-plugin/DETAILS
+++ b/xfce4-cpufreq-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-cpufreq-plugin
-         VERSION=1.1.2
+         VERSION=1.2.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:fd9ca91b99e830c6b0962a07eb269ce814ed773cd6008081771fd04060fe6ce9
+      SOURCE_VFY=sha256:c5e044c0dc401d2066f208a3df82a588b3e51ff01425f155d0a1d0f8fce8f5b5
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-cpufreq-plugin
          ENTERED=20061124
-         UPDATED=20150713
+         UPDATED=20180923
            SHORT="CpuFreq Plugin for the Xfce panel"
 
 cat << EOF

--- a/xfce4-datetime-plugin/DETAILS
+++ b/xfce4-datetime-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-datetime-plugin
-         VERSION=0.6.2
+         VERSION=0.7.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha1:5a7e665fcfd06859c45e14b7063d719b5b26885f
+      SOURCE_VFY=sha256:297f3077f7aee52a237449fbd8595e232267bc600b5b9e7ddc5baab306ed67b9
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-datetime-plugin
          ENTERED=20061124
-         UPDATED=20130217
+         UPDATED=20180819
            SHORT="date and time in the panel"
 
 cat << EOF

--- a/xfce4-dict/DETAILS
+++ b/xfce4-dict/DETAILS
@@ -1,15 +1,15 @@
           MODULE=xfce4-dict
-         VERSION=0.8.0
+         VERSION=0.8.2
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION%.*}/
-      SOURCE_VFY=sha256:3a2fa72a3fe1816e16a50327fac1926bb0167a905c9b1e313a2bf5e3163ea32a
+      SOURCE_VFY=sha256:
         WEB_SITE=http://goodies.xfce.org/projects/applications/xfce4-dict/
          ENTERED=20061124
-         UPDATED=20170627
+         UPDATED=20181207
            SHORT="Query a dictionary server for translation or explanation"
 
 cat << EOF
-With this plugin you can query a dictionary server(see RFC 2229) to
-search for the translation or explanation of a word. You can also
-choose a dictionary offered by the server to improve your search results
+With this plugin you can query a dictionary server(see RFC 2229) to search for
+the translation or explanation of a word. You can also choose a dictionary
+offered by the server to improve your search results.
 EOF

--- a/xfce4-diskperf-plugin/DETAILS
+++ b/xfce4-diskperf-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-diskperf-plugin
-         VERSION=2.5.5
+         VERSION=2.6.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}/
-      SOURCE_VFY=sha256:cbeb0c00f97362eef3f135afb77947aef73e938bae0386250a122ac6644b521b
+      SOURCE_VFY=sha256:212ddc742be3eecb6ad5554e1b1df03d5685cb71f48a558d5f895de37c57e4fa
         WEB_SITE=http://www.xfce.org
          ENTERED=20061124
-         UPDATED=20150309
+         UPDATED=20180819
            SHORT="A disk/partition performance monitor"
 
 cat << EOF

--- a/xfce4-eyes-plugin/DEPENDS
+++ b/xfce4-eyes-plugin/DEPENDS
@@ -1,1 +1,2 @@
+depends XML-Parser
 depends xfce4-panel

--- a/xfce4-eyes-plugin/DETAILS
+++ b/xfce4-eyes-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-eyes-plugin
-         VERSION=4.4.4
+         VERSION=4.5.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:240ce85b68d3d161f276ebbea97072dd6ee3df77062fd073bf6eeb4d3d1400ca
+      SOURCE_VFY=sha256:fdae00036383105a15d12e9809abd5945a8f2152b17e16ccdfbfe5bd9733f29d
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-eyes-plugin
          ENTERED=20061124
-         UPDATED=20150319
+         UPDATED=20170916
            SHORT="The eyes on your Xfce panel"
 
 cat << EOF

--- a/xfce4-fsguard-plugin/DETAILS
+++ b/xfce4-fsguard-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-fsguard-plugin
-         VERSION=1.0.2
+         VERSION=1.1.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}/
-      SOURCE_VFY=sha256:a2c8d59386ae3d23cf6bdd06a1cdd7a1b9473cf6f38ae106600b194c601040ae
+      SOURCE_VFY=sha256:
         WEB_SITE=http://www.xfce.org
          ENTERED=20061124
-         UPDATED=20150309
+         UPDATED=20180819
            SHORT="XFCE plugin to monitor free space on mount points"
 
 cat << EOF

--- a/xfce4-genmon-plugin/DETAILS
+++ b/xfce4-genmon-plugin/DETAILS
@@ -1,13 +1,11 @@
           MODULE=xfce4-genmon-plugin
-           MAJOR=3.4
-         VERSION=$MAJOR.0
+         VERSION=4.0.1
           SOURCE=$MODULE-$VERSION.tar.bz2
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$MAJOR
-      SOURCE_URL=http://archive.xfce.org/src/panel-plugins/xfce4-genmon-plugin/$MAJOR
-      SOURCE_VFY=sha1:6c249521394ee97704f2d10d0b5dd18bbb171f64
+      SOURCE_URL=http://archive.xfce.org/src/panel-plugins/xfce4-genmon-plugin/${VERSION%.*}
+      SOURCE_VFY=sha256:4c6ce37fbe71094548b44862587c2813da991aeaaecff8e572724dbbec83ab86
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-genmon-plugin
          ENTERED=20061124
-         UPDATED=20120513
+         UPDATED=20171031
            SHORT="A script monitor"
 
 cat << EOF

--- a/xfce4-mount-plugin/DETAILS
+++ b/xfce4-mount-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-mount-plugin
-         VERSION=1.1.2
+         VERSION=1.1.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:54578447abaf9da630a750d64acdc37d4fd20dda6460208d6d1ffaa9e43ee1a6
+      SOURCE_VFY=sha256:aae5bd6b984bc78daf6b5fb9d15817a27253674a4264ad60f62ccb1aa194911e
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-mount-plugin
          ENTERED=20061124
-         UPDATED=20170222
+         UPDATED=20180714
            SHORT="A mount/umount utility for the panel"
 
 cat << EOF

--- a/xfce4-mpc-plugin/DETAILS
+++ b/xfce4-mpc-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-mpc-plugin
-         VERSION=0.4.5
+         VERSION=0.5.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}/
-      SOURCE_VFY=sha256:e71f57a28915c57459d6ce0eeeee1d0934f523c0ed083158c3d3b3836fc06fcf
+      SOURCE_VFY=sha256:f1320916ae3112e6825699652a502cebfa78bb006c649b42d3d331dfe57b6cb0
         WEB_SITE=http://www.xfce.org
          ENTERED=20061124
-         UPDATED=20150309
+         UPDATED=20180820
            SHORT="A simple client Xfce plugin for Music Player Daemon"
 
 cat << EOF

--- a/xfce4-notifyd/DETAILS
+++ b/xfce4-notifyd/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-notifyd
-         VERSION=0.3.6
+         VERSION=0.4.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:f4ca7c0dadd3d4cdf8cd3c8ae60ccea77b8cf409f8517161796364eb1d766cf9
+      SOURCE_VFY=sha256:293dda084cfca4887ae740e2725fdfc64412bc10eac7a55a924eb14482dceac0
         WEB_SITE=http://goodies.xfce.org/projects/applications/xfce4-notifyd
          ENTERED=20110121
-         UPDATED=20170322
+         UPDATED=20181030
            SHORT="A notification daemon for the XFCE desktop"
 
 cat << EOF

--- a/xfce4-panel/BUILD
+++ b/xfce4-panel/BUILD
@@ -1,3 +1,3 @@
-OPTS+=" --disable-static" &&
+OPTS+=" --disable-static"
 
 default_build

--- a/xfce4-panel/BUILD
+++ b/xfce4-panel/BUILD
@@ -1,3 +1,3 @@
-OPTS+=" --disable-static"
+OPTS+=" --disable-static --enable-gio-unix"
 
 default_build

--- a/xfce4-panel/DEPENDS
+++ b/xfce4-panel/DEPENDS
@@ -1,11 +1,28 @@
 depends dbus-glib
-depends garcon
+depends hicolor-icon-theme
 depends exo
-depends libxfce4ui
-depends xfconf
+depends garcon
 depends libwnck3
+depends libxfce4ui
 
 optional_depends gtk-doc \
                  "--enable-gtk-doc" \
                  "--disable-gtk-doc" \
                  "for building documentation"
+
+optional_depends gtk+-2 \
+                 "--enable-gtk2" \
+		 "--disable-gtk2" \
+		 "For GTK+ 2 support"
+
+optional_depends gobject-introspection \
+                 "--enable-introspection" \
+		 "--disable-introspection" \
+		 "For GObject Introspection support"
+
+optional_depends vala \
+                 "--enable-vala" \
+		 "--disable-vala" \
+		 "For Vala support"
+
+

--- a/xfce4-panel/DEPENDS
+++ b/xfce4-panel/DEPENDS
@@ -1,14 +1,9 @@
-depends garcon
 depends dbus-glib
+depends garcon
 depends exo
-depends libwnck
 depends libxfce4ui
 depends xfconf
-
-optional_depends gtk+-3 \
-                 "--enable-gtk3" \
-                 "--disable-gtk3" \
-                 "for GTK 3.x support"
+depends libwnck3
 
 optional_depends gtk-doc \
                  "--enable-gtk-doc" \

--- a/xfce4-panel/DETAILS
+++ b/xfce4-panel/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-panel
-         VERSION=4.12.1
+         VERSION=4.13.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:93d58b80cca9c9eb58adb281bc75404df7cf6cae89f7f98bb9f38690009aa2e8
+      SOURCE_VFY=sha256:b467feb7ee9797ad12f56a152570e42a96b94ad63580d45536aabee282440ce8
         WEB_SITE=http://www.xfce.org/projects/xfce4-panel
          ENTERED=20030715
-         UPDATED=20161025
+         UPDATED=20181207
            SHORT="Xfce4 panel"
 
 cat << EOF

--- a/xfce4-panel/patch.d/xfce4-panel-borderfix.patch
+++ b/xfce4-panel/patch.d/xfce4-panel-borderfix.patch
@@ -1,0 +1,27 @@
+--- ./panel/panel-window.c
++++ ./panel/panel-window.c
+@@ -2112,18 +2112,18 @@ panel_window_screen_layout_changed (GdkScreen   *screen,
+               || (window->struts_edge == STRUTS_EDGE_RIGHT
+                   && b.x + b.width > a.x + a.width))
+             {
+-              dest_y = MAX (a.y, b.y);
+-              dest_h = MIN (a.y + a.height, b.y + b.height) - dest_y;
+-              if (dest_h > 0)
++              dest_x = MAX (a.x, b.x);
++              dest_w = MIN (a.x + a.width, b.x + b.width) - dest_x;
++              if (dest_w > 0)
+                 window->struts_edge = STRUTS_EDGE_NONE;
+             }
+           else if ((window->struts_edge == STRUTS_EDGE_TOP && b.y < a.y)
+                    || (window->struts_edge == STRUTS_EDGE_BOTTOM
+                        && b.y + b.height > a.y + a.height))
+             {
+-              dest_x = MAX (a.x, b.x);
+-              dest_w = MIN (a.x + a.width, b.x + b.width) - dest_x;
+-              if (dest_w > 0)
++              dest_y = MAX (a.y, b.y);
++              dest_h = MIN (a.y + a.height, b.y + b.height) - dest_y;
++              if (dest_h > 0)
+                 window->struts_edge = STRUTS_EDGE_NONE;
+             }
+         }

--- a/xfce4-power-manager/DETAILS
+++ b/xfce4-power-manager/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-power-manager
-         VERSION=1.4.4
+         VERSION=1.6.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:c50ec8aa7e7848c57c0f856dceb8132eb5f37585f0ac1627459ab8c882c73b07
+      SOURCE_VFY=sha256:1ea825452343b895566068018b6d5078608f8f46ce8075ba6bbb4b848f48656b
         WEB_SITE=http://www.xfce.org
          ENTERED=20090307
-         UPDATED=20150323
+         UPDATED=20171219
            SHORT="A power manager Xfce"
 
 cat << EOF

--- a/xfce4-screenshooter/DETAILS
+++ b/xfce4-screenshooter/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-screenshooter
-         VERSION=1.9.1
+         VERSION=1.9.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/xfce4-screenshooter/${VERSION%.*}
-      SOURCE_VFY=sha256:e62b31d9cf06a7414a26400c2ebe7a2ae7c2b22aa60f997f25145ea9ebe6e0db
+      SOURCE_VFY=sha256:
         WEB_SITE=http://www.xfce.org
          ENTERED=20061124
-         UPDATED=20170627
+         UPDATED=20181207
            SHORT="An XFCE plugin to take screenshots"
 
 cat << EOF

--- a/xfce4-session/DEPENDS
+++ b/xfce4-session/DEPENDS
@@ -1,10 +1,12 @@
+depends hicolor-icon-theme
 depends libSM
+depends libwnck3
 depends xfconf
-depends libwnck
-depends dbus-glib
 depends xfce4-panel
 depends iceauth
+depends xinit
 
-optional_depends gnome-keyring "" "" "for keyring support when GNOME compatibility is enabled"
-optional_depends upower     "" "" "Upower support"
-optional_depends polkit     "" "" "PolicyKit support"
+optional_depends polkit \
+                 "--enable-polkit" \
+		 "--disable-polkit" \
+		 "For PolicyKit support"

--- a/xfce4-session/DETAILS
+++ b/xfce4-session/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-session
-         VERSION=4.12.1
+         VERSION=4.13.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:97d7f2a2d0af7f3623b68d1f04091e02913b28f9555dab8b0d26c8a1299d08fd
+      SOURCE_VFY=sha256:c789f0f8234e06f5266f0c6ccdbdcc3c085e8d9eea06a0eafe8f7cfc4fe23af4
         WEB_SITE=http://www.xfce.org/projects/xfce4-session
          ENTERED=20030715
-         UPDATED=20150319
+         UPDATED=20181207
            PSAFE=no
            SHORT="Session manager for Xfce4"
 

--- a/xfce4-settings/CONFIGURE
+++ b/xfce4-settings/CONFIGURE
@@ -1,1 +1,1 @@
-mquery EMBEDDIALOGS "Enable support for embedded settings dialogs?" n "" "--enable-pluggable-dialogs"
+mquery EMBEDDIALOGS "Enable support for embedded settings dialogs?" n "--enable-pluggable-dialogs" "--disable-pluggable-dialogs"

--- a/xfce4-settings/DEPENDS
+++ b/xfce4-settings/DEPENDS
@@ -1,13 +1,28 @@
 depends exo
 depends garcon
 depends dbus-glib
-depends libXi
-depends libXrandr
 depends libnotify
+depends libxfce4ui
 depends intltool
 depends xfconf
-depends libxfce4ui
+depends xf86-input-libinput
 
-optional_depends libxklavier "" "" "for Libxklavier support"
-optional_depends libXcursor  "" "" "for Xcursor support"
-optional_depends libcanberra "" "" "for sound control"
+optional_depends upower \
+                 "--enable-upower-glib" \
+		 "--disable-upower-glib" \
+		 "For UPower support"
+
+optional_depends libxklavier \
+                 "--enable-libxklavier" \
+		 "--disable-libxklavier" \
+		 "For Libxklavier support"
+
+optional_depends libXcursor \
+                 "--enable-xcursor" \
+		 "--disable-xcursor" \
+		 "For Xcursor support"
+
+optional_depends libcanberra \
+                 "--enable-sound-settings" \
+		 "--disable-sound-settings" \
+		 "For sound control"

--- a/xfce4-settings/DETAILS
+++ b/xfce4-settings/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-settings
-         VERSION=4.12.1
+         VERSION=4.13.5
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:f6484a0b1a7dad65ba5ee4eba8e07299b7c92a2a8adb195684e0e2b959886574
+      SOURCE_VFY=sha256:a51408d30de1a04e88ddf7a1c9117770b1995bb93358286fd0769baa0a1edfae
         WEB_SITE=http://www.xfce.org/
          ENTERED=20090227
-         UPDATED=20160916
+         UPDATED=20181207
            SHORT="Xfce settings manager"
 
 cat << EOF

--- a/xfce4-taskmanager/DETAILS
+++ b/xfce4-taskmanager/DETAILS
@@ -1,14 +1,13 @@
           MODULE=xfce4-taskmanager
-           VERSION=1.2.0
+           VERSION=1.2.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:5746d473ad428b13db7c05cfcbc8099fbea13da6be26d3a9359bcb4de971ba69
+      SOURCE_VFY=sha256:22e523e2ee231713f40a48890d8cbae99320ac1173f7c68502f490318e1e0409
         WEB_SITE=http://www.xfce.org
          ENTERED=20061124
-         UPDATED=20170214
+         UPDATED=20180603
            SHORT="A task manager for the XFCE"
 
 cat << EOF
-Xfce4-taskmanager is a simple taskmanager for the Xfce Desktop
-Environment.
+Xfce4-taskmanager is a simple taskmanager for the Xfce Desktop Environment.
 EOF

--- a/xfce4-terminal/DEPENDS
+++ b/xfce4-terminal/DEPENDS
@@ -1,5 +1,5 @@
 depends  XML-Parser
 depends  exo
-depends  vte
+depends  vte3
 
 optional_depends  "dbus-glib"  "--enable-dbus"  "--disable-dbus"  "For DBUS support"

--- a/xfce4-terminal/DETAILS
+++ b/xfce4-terminal/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-terminal
-         VERSION=0.6.3
+         VERSION=0.8.7.4
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/apps/$MODULE/${VERSION::3}
-      SOURCE_VFY=sha1:4dd4d2bef8101f563487b0230346070930ff689f
+      SOURCE_VFY=sha256:a88f98af4da72394f2cfbd7f14b0f053ec0a3b58a4f6a577836357c60a6c42ab
         WEB_SITE=http://www.xfce.org/projects/terminal
          ENTERED=20040930
-         UPDATED=20131227
+         UPDATED=20181207
            SHORT="vte-based gtk+-2 lightweight X-terminal"
 
 cat << EOF

--- a/xfce4-weather-plugin/DETAILS
+++ b/xfce4-weather-plugin/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-weather-plugin
-         VERSION=0.8.9
+         VERSION=0.9.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/panel-plugins/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:0e15d14b3e18c3da46ad23ee3158a25220f1474a48b611de96edb56221aecee5
+      SOURCE_VFY=sha256:34368cf2332774ad2a05226b2914ecb60e7550e9b2164be53ebe8f370198bb3d
         WEB_SITE=http://goodies.xfce.org/projects/panel-plugins/xfce4-weather-plugin
          ENTERED=20061124
-         UPDATED=20170219
+         UPDATED=20181207
            SHORT="shows current weather in your panel"
 
 cat << EOF

--- a/xfce4/DEPENDS
+++ b/xfce4/DEPENDS
@@ -6,5 +6,5 @@ depends xfdesktop
 depends xfce4-session
 depends xfce4-icon-theme
 
-optional_depends Thunar     "" "" "For the new xfce4 filemanager"
-optional_depends xfce4-terminal   "" "" "For the new xfce4 xterm"
+optional_depends Thunar "" "" "For the new xfce4 filemanager"
+optional_depends xfce4-terminal "" "" "For the new xfce4 xterm"

--- a/xfconf/BUILD
+++ b/xfconf/BUILD
@@ -1,3 +1,3 @@
-OPTS+=" --disable-static" &&
+OPTS+=" --disable-static --disable-gtk-doc" &&
 
 default_build

--- a/xfconf/DEPENDS
+++ b/xfconf/DEPENDS
@@ -2,7 +2,8 @@ depends dbus-glib
 depends libxfce4util
 depends intltool
 
-optional_depends gtk-doc \
-                 "--enable-gtk-doc" \
-                 "--disable-gtk-doc" \
-                 "for building documentation"
+# broken
+#optional_depends gtk-doc \
+#                 "--enable-gtk-doc" \
+#                 "--disable-gtk-doc" \
+#                 "for building documentation"

--- a/xfconf/DETAILS
+++ b/xfconf/DETAILS
@@ -1,11 +1,11 @@
         MODULE=xfconf
-       VERSION=4.12.1
+       VERSION=4.13.6
         SOURCE=$MODULE-$VERSION.tar.bz2
     SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-    SOURCE_VFY=sha256:35f48564e5694faa54fdc180cd3268e16fc2352946a89a3c2fc12cbe400ada36
+    SOURCE_VFY=sha256:d1a3d442dae188b5a7380b5815377e5488578cdafb03ae363e9426e3b01185df
       WEB_SITE=http://www.xfce.org
        ENTERED=20090227
-       UPDATED=20161025
+       UPDATED=20181207
          SHORT="Configuration system for Xfce"
 
 cat << EOF

--- a/xfdesktop/CONFIGURE
+++ b/xfdesktop/CONFIGURE
@@ -1,0 +1,1 @@
+mquery DESTKOPMENU "Enable support for desktop menu?" y "--enable-desktop-menu" "--disable-desktop-menu"

--- a/xfdesktop/DEPENDS
+++ b/xfdesktop/DEPENDS
@@ -1,8 +1,12 @@
-depends xfconf
-depends dbus-glib
 depends exo
 depends garcon
-depends libnotify
-depends libwnck
+depends hicolor-icon-theme
+depends libwnck3
+depends libxfce4ui
 
-optional_depends Thunar "" "" "for desktop file icon support"
+optional_depends Thunar \
+                 "--enable-desktop-icons --enable-thunarx" \
+		 "--disable-desktop-icons --disable-thunarx" \
+		 "for desktop icons support"
+
+optional_depends libnotify "--enable-notifications" "--disable-notifications" "for notification"

--- a/xfdesktop/DETAILS
+++ b/xfdesktop/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfdesktop
-         VERSION=4.12.3
+         VERSION=4.13.2
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:a8a8d93744d842ca6ac1f9bd2c8789ee178937bca7e170e5239cbdbef30520ac
+      SOURCE_VFY=sha256:387f43d8a4615f44060c019cad212ac12df62c58eea2605813743116f71ad3bd
         WEB_SITE=http://www.xfce.org
          ENTERED=20030715
-         UPDATED=20150720
+         UPDATED=20181207
            SHORT="Desktop manager for Xfce4"
 
 cat << EOF

--- a/xfwm4/DEPENDS
+++ b/xfwm4/DEPENDS
@@ -1,5 +1,4 @@
 depends libwnck3
-depends libxfcegui4
 depends libxfce4ui
-depends xfconf
+depends libdrm
 depends startup-notification

--- a/xfwm4/DEPENDS
+++ b/xfwm4/DEPENDS
@@ -1,4 +1,4 @@
-depends libwnck
+depends libwnck3
 depends libxfcegui4
 depends libxfce4ui
 depends xfconf

--- a/xfwm4/DETAILS
+++ b/xfwm4/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfwm4
-         VERSION=4.12.4
+         VERSION=4.13.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:fa74048a75649a6e92df763a3cfb706d3fed1e1a6adf567f6693325a5a6efb36
+      SOURCE_VFY=sha256:75ebc20d313cff4905e76fc320254c30461dbfa985461b8e75dca04770cedf12
         WEB_SITE=http://www.xfce.org/
          ENTERED=20030715
-         UPDATED=20170627
+         UPDATED=20181207
            SHORT="Window manager for Xfce4"
 
 cat << EOF


### PR DESCRIPTION
While half the work was updating the core Xfce components to 4.13.x, the other half of the work was from @Florin65's repo.

This superceeds https://github.com/lunar-linux/moonbase-xfce/pull/127