### PR TITLE
xfce4-sensors-plugin - GCC 10 fix

### DIFF
--- a/xfce4-sensors-plugin/BUILD
+++ b/xfce4-sensors-plugin/BUILD
@@ -1,5 +1,5 @@
 OPTS+=" --disable-static \
         --disable-debug \
         --disable-pathchecks"
-
+CFLAGS=" -fcommon"
 default_build


### PR DESCRIPTION
Added -fcommon to BUILD, so this compiles with GCC 10.