### PR TITLE
Xfce 4.16 base

### DIFF
--- a/exo/BUILD
+++ b/exo/BUILD
@@ -1,4 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug"
+OPTS+="  --disable-debug"
 
 default_build

--- a/exo/DEPENDS
+++ b/exo/DEPENDS
@@ -1,16 +1,8 @@
 depends URI
 depends libxfce4ui
-depends hicolor-icon-theme
-depends intltool
-
-optional_depends gtk+-2 \
-                 "--enable-gtk2" \
-                 "--disable-gtk2" \
-                 "for GTK 2.x support" \
-                 "n"
 
 optional_depends gtk-doc \
                  "--enable-gtk-doc"  \
-                 "--disable-gtk-doc" \
+                 "" \
                  "for building documentation" \
                  "n"

--- a/exo/DETAILS
+++ b/exo/DETAILS
@@ -1,11 +1,11 @@
           MODULE=exo
-         VERSION=0.12.11
+         VERSION=4.16.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:ec892519c08a67f3e0a1f0f8d43446e26871183e5aa6be7f82e214f388d1e5b6
+      SOURCE_VFY=sha256:1975b00eed9a8aa1f899eab2efaea593731c19138b83fdff2f13bdca5275bacc
         WEB_SITE=https://www.xfce.org/
          ENTERED=20040930
-         UPDATED=20200314
+         UPDATED=20201223
            SHORT="The Xfce extension library"
 
 cat << EOF

--- a/libxfce4ui/BUILD
+++ b/libxfce4ui/BUILD
@@ -1,4 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug"
+OPTS+="  --disable-debug"
 
 default_build

--- a/libxfce4ui/DEPENDS
+++ b/libxfce4ui/DEPENDS
@@ -1,23 +1,35 @@
 depends gtk+-3
-depends libxml2
 depends libxfce4util
 depends xfconf
-depends intltool
+
+optional_depends libepoxy \
+   "" \
+   "--disable-epoxy" \
+   "for libepoxy OpenGL support" \
+   "y"
+
+optional_depends libgtop \
+   "" \
+   "--disable-glibtop" \
+   "for libGtop support" \
+   "y"
+
+optional_depends libgudev \
+   "" \
+   "--disable-gudev" \
+   "for GObject udev support" \
+   "y"
 
 optional_depends startup-notification \
                  "--enable-startup-notification" \
                  "--disable-startup-notification" \
-                 "for startup notification support"
+                 "for startup notification support" \
+                 "y"
 
 optional_depends vala \
                  "--enable-vala=yes" \
                  "--enable-vala=no" \
-                 "for vala support"
-
-optional_depends libglade \
-                 "--enable-gladeui2" \
-                 "--disable-gladeui2" \
-                 "for glade inbterface designer" \
+                 "for vala support" \
                  "n"
 
 optional_depends gobject-introspection \
@@ -25,12 +37,3 @@ optional_depends gobject-introspection \
                  "--enable-introspection=no" \
                  "for object introspection" \
                  "y"
-# not real depends, but we really want them
-#depends gtk-xfce-engine
-depends xfce4-icon-theme
-
-optional_depends gtk+-2 \
-                 "--enable-gtk2" \
-                 "--disable-gtk2" \
-                 "for GTK 2.x support" \
-                 "n"

--- a/libxfce4ui/DETAILS
+++ b/libxfce4ui/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libxfce4ui
-         VERSION=4.14.1
+         VERSION=4.16.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:c449075eaeae4d1138d22eeed3d2ad7032b87fb8878eada9b770325bed87f2da
+      SOURCE_VFY=sha256:8b06c9e94f4be88a9d87c47592411b6cbc32073e7af9cbd64c7b2924ec90ceaa
         WEB_SITE=http://www.xfce.org
          ENTERED=20030715
-         UPDATED=20200314
+         UPDATED=20201223
            SHORT="Widget library for Xfce4"
 
 cat << EOF

--- a/libxfce4util/BUILD
+++ b/libxfce4util/BUILD
@@ -1,4 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug"
+OPTS+="  --disable-debug"
 
 default_build

--- a/libxfce4util/DEPENDS
+++ b/libxfce4util/DEPENDS
@@ -1,7 +1,9 @@
-depends glib-2
-depends intltool
-depends vala
-
+optional_depends vala \
+                 "--enable-vala=yes" \
+                 "--enable-vala=no" \
+                 "for vala support" \
+                 "n"
+                 
 optional_depends gobject-introspection \
                  "--enable-introspection=yes" \
                  "--enable-introspection=no" \

--- a/libxfce4util/DETAILS
+++ b/libxfce4util/DETAILS
@@ -1,11 +1,11 @@
           MODULE=libxfce4util
-         VERSION=4.14.0
+         VERSION=4.16.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:32ad79b7992ec3fd863e8ff2f03eebda8740363ef9d7d910a35963ac1c1a6324
+      SOURCE_VFY=sha256:60598d745d1fc81ff5ad3cecc3a8d1b85990dd22023e7743f55abd87d8b55b83
         WEB_SITE=http://www.xfce.org
          ENTERED=20030715
-         UPDATED=20200314
+         UPDATED=20201223
            SHORT="A utility library for Xfce4"
 
 cat << EOF

--- a/xfconf/BUILD
+++ b/xfconf/BUILD
@@ -1,4 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug"
+OPTS+=" --disable-debug"
 
 default_build

--- a/xfconf/DEPENDS
+++ b/xfconf/DEPENDS
@@ -1,6 +1,6 @@
-#depends dbus-glib
+depends dbus-glib
 depends libxfce4util
-depends intltool
+
 
 optional_depends vala \
                  "--enable-vala=yes" \

--- a/xfconf/DETAILS
+++ b/xfconf/DETAILS
@@ -1,11 +1,11 @@
         MODULE=xfconf
-       VERSION=4.14.4
+       VERSION=4.16.0
         SOURCE=$MODULE-$VERSION.tar.bz2
     SOURCE_URL=https://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-    SOURCE_VFY=sha256:cc37622eece51ed8905dfaad6f77b3c24662f41881545eb0142110f347ba5f73
+    SOURCE_VFY=sha256:652a119007c67d9ba6c0bc7a740c923d33f32d03dc76dfc7ba682584e72a5425
       WEB_SITE=http://www.xfce.org
        ENTERED=20090227
-       UPDATED=20201109
+       UPDATED=20201223
          SHORT="Configuration system for Xfce"
 
 cat << EOF


### PR DESCRIPTION
The core libraries of Xfce, that the others rely on.

General:

- these are mostly version bumps.
- In the BUILD files, --disable-static has been removed. It's now disabled by default.
- In DEPENDS, intltool has been removed - it's part of Lunar core and is already installed.
- GTK2 support has been removed.