### PR TITLE
xfce4-panel 4.16

### DIFF
--- a/xfce4-panel/BUILD
+++ b/xfce4-panel/BUILD
@@ -1,8 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug \
-        --enable-gio-unix"
-
-# introspection is breaking the build
-OPTS+=" --enable-introspection=no"
+OPTS+="  --disable-debug"
 
 default_build

--- a/xfce4-panel/DEPENDS
+++ b/xfce4-panel/DEPENDS
@@ -1,27 +1,27 @@
 depends exo
 depends garcon
 depends libwnck3
-depends libxfce4ui
-depends xfconf
-depends vala
-depends hicolor-icon-theme
-depends desktop-file-utils
 
+optional_depends libdbusmenu-gtk3 \
+                 "--enable-dbusmenu-gtk3=yes" \
+                 "--enable-dbusmenu-gtk3=no" \
+                 "for dbus menu support"
+                 "y"
+
+optional_depends vala \
+                 "--enable-vala=yes" \
+                 "--enable-vala=no" \
+                 "for vala support"
+                 "n"
+                 
 optional_depends gtk-doc \
                  "--enable-gtk-doc" \
                  "--disable-gtk-doc" \
                  "for building documentation" \
                  "n"
 
-# it breaks the build
-#optional_depends gobject-introspection \
-#                 "--enable-introspection=yes" \
-#                 "--enable-introspection=no" \
-#                 "for object introspection" \
-#                 "y"
-
-optional_depends gtk+-2 \
-                 "--enable-gtk2" \
-                 "--disable-gtk2" \
-                 "for GTK 2.x support" \
-                 "n"
+optional_depends gobject-introspection \
+                 "--enable-introspection=yes" \
+                 "--enable-introspection=no" \
+                 "for object introspection" \
+                 "y"

--- a/xfce4-panel/DETAILS
+++ b/xfce4-panel/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfce4-panel
-         VERSION=4.14.4
+         VERSION=4.16.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:8e5ea79412ba84cfada897ff309cbe2cd4aca16b9bd4f93df060229528576fd5
+      SOURCE_VFY=sha256:5e979aeeb37d306d72858b1bc67448222ea7a68de01409055b846cd31f3cc53d
         WEB_SITE=http://www.xfce.org/projects/xfce4-panel
          ENTERED=20030715
-         UPDATED=20200428
+         UPDATED=20201223
            SHORT="Xfce4 panel"
 
 cat << EOF


### PR DESCRIPTION
version bump.

Also:
- introspection works properly
- dbusmenu-gtk3 optional_depends
- drop gtk2 support