### PR TITLE
Xfce4 session

### DIFF
--- a/xfce4-session/BUILD
+++ b/xfce4-session/BUILD
@@ -1,4 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug"
+OPTS+="  --disable-debug"
 
 default_build

--- a/xfce4-session/CONFIGURE
+++ b/xfce4-session/CONFIGURE
@@ -1,0 +1,4 @@
+mquery USE_LEGACY_SM \
+  "Enable legacy X11R5 session support?" n \
+  " --enable-legacy-sm" \
+  " --disable-legacy-sm"

--- a/xfce4-session/DEPENDS
+++ b/xfce4-session/DEPENDS
@@ -1,15 +1,8 @@
-depends libSM
-depends xfconf
 depends libwnck3
-depends xrdb
 depends iceauth
-depends xinit
-depends hicolor-icon-theme
+
 
 optional_depends polkit \
                  "--enable-polkit" \
                  "--disable-polkit" \
                  " for PolicyKit support"
-
-optional_depends gnome-keyring "" "" "for keyring support when GNOME compatibility is enabled"
-optional_depends upower     "" "" "Upower support"

--- a/xfce4-session/DETAILS
+++ b/xfce4-session/DETAILS
@@ -1,12 +1,11 @@
           MODULE=xfce4-session
-         VERSION=4.14.2
+         VERSION=4.16.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:fbe3a4a60c91589a2024ce12b2d2667625a8fedcbc90ef031831f56319f597af
+      SOURCE_VFY=sha256:22f273f212481d71e0b5618c62710cd85f69aea74f5ea5c0093f7918b07d17b7
         WEB_SITE=http://www.xfce.org/projects/xfce4-session
          ENTERED=20030715
-         UPDATED=20200329
-           PSAFE=no
+         UPDATED=20201223
            SHORT="Session manager for Xfce4"
 
 cat << EOF

--- a/xfce4-session/patch.d/source-system-xinitrc-scripts.patch
+++ b/xfce4-session/patch.d/source-system-xinitrc-scripts.patch
@@ -1,6 +1,6 @@
-diff -upr xfce4-session-4.14.0.orig/scripts/xinitrc.in.in xfce4-session-4.14.0/scripts/xinitrc.in.in
---- ./scripts/xinitrc.in.in	2019-08-11 23:11:06.000000000 +0300
-+++ ./scripts/xinitrc.in.in	2019-08-12 03:28:44.464707715 +0300
+diff -upr scripts/xinitrc.in.in scripts/xinitrc.in.in
+--- ./scripts/xinitrc.in.in   2019-08-11 23:11:06.000000000 +0300
++++ ./scripts/xinitrc.in.in   2019-08-12 03:28:44.464707715 +0300
 @@ -83,6 +83,13 @@ if command -v systemctl >/dev/null 2>&1
    dbus-update-activation-environment --systemd XAUTHLOCALHOSTNAME=$XAUTHLOCALHOSTNAME
  fi


### PR DESCRIPTION
4.16 version bump

- added CONFIGURE option for legacy session management support
- removed optional_depends for gnome-keyring and upower - the configure doesn't look for these.