### PR TITLE
xfdesktop 4.16

### DIFF
--- a/xfdesktop/BUILD
+++ b/xfdesktop/BUILD
@@ -1,4 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug"
+OPTS+="  --disable-debug"
 
 default_build

--- a/xfdesktop/DEPENDS
+++ b/xfdesktop/DEPENDS
@@ -1,6 +1,5 @@
 depends exo
 depends garcon
-depends libnotify
 depends libwnck3
 
 optional_depends libnotify \

--- a/xfdesktop/DETAILS
+++ b/xfdesktop/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xfdesktop
-         VERSION=4.14.3
+         VERSION=4.16.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://archive.xfce.org/src/xfce/$MODULE/${VERSION%.*}
-      SOURCE_VFY=sha256:06d7d08f41a847f539e9aeb52ed715f960255dc1b2162a60e5f90661892a5793
+      SOURCE_VFY=sha256:934ba5affecff21e62d9fac1dd50c50cd94b3a807fefa5f5bff59f3d6f155bae
         WEB_SITE=http://www.xfce.org
          ENTERED=20030715
-         UPDATED=20201106
+         UPDATED=20201223
            SHORT="Desktop manager for Xfce4"
 
 cat << EOF


### PR DESCRIPTION
4.16 version bump

- moved libnotify to optional dependency.