### PR TITLE
tumbler 4.16

### DIFF
--- a/tumbler/BUILD
+++ b/tumbler/BUILD
@@ -1,5 +1,3 @@
-OPTS+=" --disable-static \
-        --disable-debug \
-        -disable-gstreamer-thumbnailer"
+OPTS+=" --disable-debug"
 
 default_build

--- a/tumbler/DEPENDS
+++ b/tumbler/DEPENDS
@@ -1,10 +1,10 @@
 depends dbus-glib
 depends gdk-pixbuf
-depends freetype2
-depends intltool
 
+optional_depends freetype2 "" "" "for font thumbnails"
+optional_depends %JPEG "" "" "for jpeg thumbnails from exif data"
 optional_depends ffmpegthumbnailer "" "" "for video thumbnails"
-
 optional_depends gstreamer "" "" "second video thumbnail backend"
-optional_depends libgsf    "" "" "for ODF thumbnails"
 optional_depends poppler   "" "" "for PDF thumbnails"
+optional_depends libgsf    "" "" "for ODF thumbnails"
+optional_depends libopenraw "" "" "for RAW image thumbnails"

--- a/tumbler/DETAILS
+++ b/tumbler/DETAILS
@@ -1,12 +1,11 @@
           MODULE=tumbler
-         VERSION=0.2.8
+         VERSION=4.16.0
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://archive.xfce.org/src/xfce/tumbler/${VERSION%.*}
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha256:0999b9a3deb57010956db6630ae7205813999147043171049a7b6c333be93e96
+      SOURCE_VFY=sha256:9b0b7fed0c64041733d490b1b307297984629d0dd85369749617a8766850af66
         WEB_SITE=http://xfce.org
          ENTERED=20110418
-         UPDATED=20200314
+         UPDATED=20201223
            SHORT="XFCE thumbnailer"
 
 cat <<EOF

--- a/tumbler/PRE_BUILD
+++ b/tumbler/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+## looking for older libopenraw that doesn't exist anymore
+sed -i 's/libopenraw-gnome-0.1/libopenraw-gnome-0.3/g' configure


### PR DESCRIPTION
4.16 version bump
- gstreamer thumbnailer now works
- added a PRE_BUILD to catch up to the new libopenraw version.