### PR TITLE
xfce/crater: add a basic README

### DIFF
--- a/crater/README
+++ b/crater/README
@@ -1,0 +1,9 @@
+The crater subdirectory is where badly broken modules go until the complete
+removal can be done. The reasons to move a module there can include:
+  - The source archive is nowhere to be found on the internet;
+  - The source code doesn't compile anymore or is broken due to deprecations
+    and there's no maintenance done upstream;
+  - The module has been replaced by a new one.
+
+Complete removal will be made once no problems have been reported for a good
+while and that most modules have been tested to work well without it.


### PR DESCRIPTION
The creation of this file is mostly justified to keep the directory present even if there's no modules in it. And it doesn't hurt to add a little description to it :)